### PR TITLE
Add Beacon and Multi-Event capabilities

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -77,12 +77,16 @@ runs:
             fi
         fi
         ## Add beacon_id input if provided for launch or check
-        if ([ "${{ inputs.command }}" = "launch" ] || [ "${{ inputs.command }}" = "check" ]) && [ -n "${{ inputs.beacon_id }}" ]; then
-            COMMAND="$COMMAND --beacon-id ${{ inputs.beacon_id }}"
+        if [ "${{ inputs.command }}" = "launch" ] || [ "${{ inputs.command }}" = "check" ]; then
+            if [ -n "${{ inputs.beacon_id }}" ]; then
+                COMMAND="$COMMAND --beacon-id ${{ inputs.beacon_id }}"
+            fi
         fi
         ## Add event_slug input if provided for launch or check
-        if [ "${{ inputs.command }}" = "launch" ] || [ "${{ inputs.command }}" = "check" ] && [ -n "${{ inputs.event_slug }}" ]; then
-            COMMAND="$COMMAND --event-slug ${{ inputs.event_slug }}"
+        if [ "${{ inputs.command }}" = "launch" ] || [ "${{ inputs.command }}" = "check" ]; then
+            if [ -n "${{ inputs.event_slug }}" ]; then
+                COMMAND="$COMMAND --event-slug ${{ inputs.event_slug }}"
+            fi
         fi
         ## Add uuid input if needed
         if [ "${{ inputs.command }}" = "cancel" ] || [ "${{ inputs.command }}" = "info" ] || [ "${{ inputs.command }}" = "status" ] || [ "${{ inputs.command }}" = "success" ] || [ "${{ inputs.command }}" = "await" ]; then

--- a/action.yaml
+++ b/action.yaml
@@ -81,7 +81,7 @@ runs:
             COMMAND="$COMMAND --beacon-id ${{ inputs.beacon_id }}"
         fi
         ## Add event_slug input if provided for launch or check
-        if ([ "${{ inputs.command }}" = "launch" ] || [ "${{ inputs.command }}" = "check" ]) && [ -n "${{ inputs.event_slug }}" ]; then
+        if [ "${{ inputs.command }}" = "launch" ] || [ "${{ inputs.command }}" = "check" ] && [ -n "${{ inputs.event_slug }}" ]; then
             COMMAND="$COMMAND --event-slug ${{ inputs.event_slug }}"
         fi
         ## Add uuid input if needed

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 name: 'Ethiack Job Manager Action'
 description: 'Integrates Ethiack Job Manager with GitHub Actions for managing Artiacker jobs.'
-author: 'Ethiack, Lda.'
+author: 'Ethiack, Lda'
 
 branding:
   icon: 'search'
@@ -16,6 +16,14 @@ inputs:
     default: ''
   url:
     description: 'The URL of the target service. Required for commands "launch", and "check".'
+    required: false
+    default: ''
+  beacon_id:
+    description: 'The beacon ID of the service. Optional for commands "launch" and "check".'
+    required: false
+    default: ''
+  event_slug:
+    description: 'The event slug of the service. Optional for commands "launch" and "check".'
     required: false
     default: ''
   args:
@@ -68,7 +76,14 @@ runs:
                 exit 1
             fi
         fi
-
+        ## Add beacon_id input if provided for launch or check
+        if ([ "${{ inputs.command }}" = "launch" ] || [ "${{ inputs.command }}" = "check" ]) && [ -n "${{ inputs.beacon_id }}" ]; then
+            COMMAND="$COMMAND --beacon-id ${{ inputs.beacon_id }}"
+        fi
+        ## Add event_slug input if provided for launch or check
+        if ([ "${{ inputs.command }}" = "launch" ] || [ "${{ inputs.command }}" = "check" ]) && [ -n "${{ inputs.event_slug }}" ]; then
+            COMMAND="$COMMAND --event-slug ${{ inputs.event_slug }}"
+        fi
         ## Add uuid input if needed
         if [ "${{ inputs.command }}" = "cancel" ] || [ "${{ inputs.command }}" = "info" ] || [ "${{ inputs.command }}" = "status" ] || [ "${{ inputs.command }}" = "success" ] || [ "${{ inputs.command }}" = "await" ]; then
             if [ -n "${{ inputs.uuid }}" ]; then


### PR DESCRIPTION
This pull request includes updates to the `action.yaml` file for the Ethiack Job Manager Action. The most important changes include the addition of new inputs and the corresponding logic to handle these inputs in the `runs` section.

### Updates to `action.yaml`:

* **Author Information Update:**
  - Removed the comma from the author's name. (`[action.yamlL3-R3](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL3-R3)`)

* **New Inputs Added:**
  - Added `beacon_id` input, which is optional for the "launch" and "check" commands. (`[action.yamlR21-R28](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR21-R28)`)
  - Added `event_slug` input, which is also optional for the "launch" and "check" commands. (`[action.yamlR21-R28](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR21-R28)`)

* **Logic to Handle New Inputs:**
  - Included logic to add the `beacon_id` input to the command if provided for the "launch" or "check" commands. (`[action.yamlL71-R90](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL71-R90)`)
  - Included logic to add the `event_slug` input to the command if provided for the "launch" or "check" commands. (`[action.yamlL71-R90](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL71-R90)`)Users can now specify the Beacon and the Event they want to run the scans on, thus enabling CI/CD scanning of internal assets and multiple machine events.
