### PR TITLE
ci: update commitlint config

### DIFF
--- a/.github/configs/commitlint.config.js
+++ b/.github/configs/commitlint.config.js
@@ -1,27 +1,9 @@
-const { maxLineLength } = require('@commitlint/ensure')
-
-const bodyMaxLineLength = 100
-
-const validateBodyMaxLengthIgnoringDeps = (parsedCommit) => {
-  const { type, scope, body } = parsedCommit
-  const isDepsCommit =
-    type === 'chore' && scope === 'release'
-
-  return [
-    isDepsCommit || !body || maxLineLength(body, bodyMaxLineLength),
-    `body's lines must not be longer than ${bodyMaxLineLength}`,
-  ]
-}
-
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  plugins: ['commitlint-plugin-function-rules'],
   rules: {
-    'body-max-line-length': [0],
-    'function-rules/body-max-line-length': [
-      2,
-      'always',
-      validateBodyMaxLengthIgnoringDeps,
-    ],
+	'body-max-line-length': [1, 'always', 100], // warning
+	'header-max-length': [1, 'always', 100], // warning
+	'footer-max-line-length': [1, 'always', 100], // warning
+	'subject-case': [1, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']], // warning
   },
 }


### PR DESCRIPTION
This pull request includes changes to the `.github/configs/commitlint.config.js` file to simplify and standardize commit message linting rules. The most important changes include removing custom validation logic and adding standardized rules for line lengths and subject casing.

Standardization of commit message linting rules:

* Removed custom validation function `validateBodyMaxLengthIgnoringDeps` and its associated plugin.
* Added standardized rules for `body-max-line-length`, `header-max-length`, and `footer-max-line-length`, setting them to a warning level with a maximum of 100 characters.
* Added a rule for `subject-case` to warn against using sentence-case, start-case, pascal-case, and upper-case.