### PR TITLE
docs: updating company legal name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Ethiack, Lda.
+Copyright (c) 2025 Ethiack, S.A.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 name: 'Ethiack Job Manager Action'
 description: 'Integrates Ethiack Job Manager with GitHub Actions for managing Artiacker jobs.'
-author: 'Ethiack, Lda'
+author: 'Ethiack, S.A.'
 
 branding:
   icon: 'search'


### PR DESCRIPTION
This pull request makes minor updates to the project metadata, reflecting the company's new legal name and copyright year.

* Updated copyright year to 2025 and changed company name from "Ethiack, Lda." to "Ethiack, S.A." in the `LICENSE` file.
* Updated author field to "Ethiack, S.A." in the `action.yaml` file.